### PR TITLE
Manifest: set sync-tags to 'false'

### DIFF
--- a/slim.xml
+++ b/slim.xml
@@ -2,14 +2,18 @@
 <manifest>
 
   <remote  name="aosp"
+           sync-tags="false"
            fetch="https://android.googlesource.com/" />
 
   <remote  name="github"
+           sync-tags="false"           
            fetch="git://github.com/"
            review="https://gerrit.slimroms.net/"/>
 
   <default revision="refs/tags/android-4.4.4_r2.0.1"
+           sync-tags="false"           
            remote="aosp"
+           sync-c="true"
            sync-j="4" />
 
   <project path="abi/cpp" name="platform/abi/cpp" groups="pdk" />


### PR DESCRIPTION
It does not really make sense to synchronize the AOSP tags in this build
tree; this will help to save time duing synch and also disk space.